### PR TITLE
Fix race condition

### DIFF
--- a/message.go
+++ b/message.go
@@ -13,7 +13,7 @@ type Message struct {
 	Headers map[string]interface{}
 	Config  []byte
 
-	msg *amqp.Delivery
+	msg amqp.Delivery
 }
 
 type InitialMessage struct {
@@ -22,7 +22,7 @@ type InitialMessage struct {
 	Config json.RawMessage `json:"config"`
 }
 
-func NewMessage(msg *amqp.Delivery) (*Message, error) {
+func NewMessage(msg amqp.Delivery) (*Message, error) {
 	var initialMessage InitialMessage
 
 	if err := json.Unmarshal(msg.Body, &initialMessage); err != nil {

--- a/service.go
+++ b/service.go
@@ -203,8 +203,7 @@ func (s *Service) GetMessages() (<-chan *Message, error) {
 
 	go func() {
 		for msg := range msgs {
-			cmsg := msg
-			m, err := NewMessage(&cmsg)
+			m, err := NewMessage(msg)
 			if err != nil {
 				msg.Ack(false)
 				continue

--- a/service.go
+++ b/service.go
@@ -124,7 +124,7 @@ func (s *Service) PublishMessage(exchange string, key string, chain []*ChainItem
 }
 
 func (s Service) Next(msg *Message, data interface{}, headers map[string]interface{}) error {
-	err := msg.Ack(true)
+	err := msg.Ack(false)
 	if err != nil {
 		return err
 	}
@@ -203,7 +203,8 @@ func (s *Service) GetMessages() (<-chan *Message, error) {
 
 	go func() {
 		for msg := range msgs {
-			m, err := NewMessage(&msg)
+			cmsg := msg
+			m, err := NewMessage(&cmsg)
 			if err != nil {
 				msg.Ack(false)
 				continue


### PR DESCRIPTION
Now when Qos is > 1, two accidents happen:

- All future messages would be acknowledged due to Ack(true)
- Library tries to ack message that has been overwritten by next in range loop